### PR TITLE
Allowed setting the default department for new Zendesk chats

### DIFF
--- a/addon/components/help-widget.hbs
+++ b/addon/components/help-widget.hbs
@@ -2,6 +2,7 @@
   class="ember-help-widget {{if this.isOpen "ember-help-widget-open"}}"
   ...attributes
   {{did-insert this.connectChat}}
+  {{did-update this.updateChatInfo @departmentId}}
   {{did-update this.updateChatInfo @currentUserName}}
   {{did-update this.updateChatInfo @currentUserEmail}}
 >

--- a/addon/components/help-widget.js
+++ b/addon/components/help-widget.js
@@ -73,6 +73,7 @@ export default class HelpWidgetComponent extends Component {
 
   @action
   updateChatInfo() {
+    this.zendeskChat.departmentId = this.args.departmentId;
     this.zendeskChat.currentUserName = this.args.currentUserName;
     this.zendeskChat.currentUserEmail = this.args.currentUserEmail;
     this.zendeskChat.sendUserInfo();

--- a/addon/services/zendesk-chat.js
+++ b/addon/services/zendesk-chat.js
@@ -13,6 +13,7 @@ export default class ZendeskChatService extends Service {
 
   @tracked currentUserName = null;
   @tracked currentUserEmail = null;
+  @tracked departmentId = null;
   @tracked chatTags = [];
 
   @tracked _connectionStatus = 'closed';
@@ -199,13 +200,28 @@ export default class ZendeskChatService extends Service {
 
 
 
-  sendUserInfo() {
+  async sendUserInfo() {
+    await this._sendDepartment();
+    await this._sendUserIdentifcation();
+  }
+
+  _sendUserIdentifcation() {
     return new EmberPromise((resolve, reject) => {
       if (!this.isConnected) { return reject(); }
       zChat.setVisitorInfo({
         display_name: this.currentUserName,
         email: this.currentUserEmail
       }, err => { if (err) { reject(err); } else { resolve(); } });
+    });
+  }
+
+  _sendDepartment() {
+    return new EmberPromise((resolve, reject) => {
+      if (!this.isConnected) { return reject(); }
+      if (!this.departmentId) { return resolve(); }
+      zChat.setVisitorDefaultDepartment(
+        this.departmentId,
+        err => { if (err) { reject(err); } else { resolve(); } });
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cph/ember-help-widget",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
### Summary
Allows providing a Department ID, which will be set as the default for the user whenever they start a new chat.