### PR TITLE
Fixed esoteric error from interaction with ember-auto-import

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,12 @@ module.exports = {
   name: require('./package').name,
 
   included() {
+    // This initialization is done by ember-cli-mirage before running _super.included.
+    // Without it, the addon seems to be elevated in an unhelpful way that causes
+    // ember-auto-import to import the webpacker settings of the root project twice.
+    const app = this._findHost();
+    this.app = app;
+
     this._super.included.apply(this, arguments);
     this.import('vendor/zendesk-chat/web-sdk.js', { using: [{ transformation: 'amd', as: 'zendesk-chat-sdk' }] });
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cph/ember-help-widget",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
### Summary
Still not _quite_ sure why, but without this extra initialization, `ember-auto-import` was making this app a peer to `ember-auto-import`, which resulted in including the root "builder" package twice, which copied its webpack config twice over, resulting in webpack trying to run everything through its pipeline _twice_ (which doesn't work especially with CSS -- you can only translate CSS to JS once!) 😆

In any case, having this extra initialization seems to appropriately set this up as an addon, resulting in a successful build. 🤷‍♂️