### PR TITLE
No Zendesk, No Problem

### DIFF
--- a/addon/services/zendesk-chat.js
+++ b/addon/services/zendesk-chat.js
@@ -65,6 +65,8 @@ export default class ZendeskChatService extends Service {
     this._observeRoute();
     this._observeChat();
 
+    if (!zChat) { return; }
+
     if (!this.#initialized) {
       this.#initialized = true;
       zChat.init({
@@ -165,7 +167,7 @@ export default class ZendeskChatService extends Service {
 
   getHours() {
     return new EmberPromise((resolve, reject) => {
-      const hours = zChat.getOperatingHours();
+      const hours = zChat && zChat.getOperatingHours();
       if (hours === undefined) {
         reject();
       } else {
@@ -229,11 +231,13 @@ export default class ZendeskChatService extends Service {
   _sendPathInfo() {
     const url = window.location.href,
           title = window.document.title;
-    zChat.sendVisitorPath({ title, url });
+    zChat && zChat.sendVisitorPath({ title, url });
   }
 
   _addTags() {
     return new EmberPromise((resolve, reject) => {
+      if (!zChat) { return resolve(); }
+
       zChat.addTags(this.chatTags, err => {
         if (err) { reject(err); } else { resolve(); }
       });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cph/ember-help-widget",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
### Summary

Some content blockers like DuckDuckGo block Zendesk's SDK as a tracker. That shouldn't crash the widget (or the whole site!)