### PR TITLE
Bumped xmldom to 0.7.0 to address CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
   },
   "resolutions": {
     "ember-cli-babel": "^7.22.1 <7.24.0",
+    "glob-parent": "^5.1.2",
+    "normalize-url": "^4.5",
     "printf": "^0.6.1",
     "ssri": "^8.0.1",
-    "normalize-url": "^4.5",
-    "glob-parent": "^5.1.2"
+    "xmldom": "github:xmldom/xmldom#0.7.0"
   },
   "dependencies": {
     "@glimmer/component": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11453,10 +11453,9 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xmldom@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.6.0.tgz#43a96ecb8beece991cef382c08397d82d4d0c46f"
-  integrity sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==
+xmldom@^0.6.0, "xmldom@github:xmldom/xmldom#0.7.0":
+  version "0.7.0"
+  resolved "https://codeload.github.com/xmldom/xmldom/tar.gz/c568938641cc1f121cef5b4df80fcfda1e489b6e"
 
 xmlhttprequest-ssl@~1.6.2:
   version "1.6.2"


### PR DESCRIPTION
### Summary
It would seem that the xmldom team is unable to publish this version to npm for some reason, so we'll use the code from GH. (cf. https://github.com/xmldom/xmldom/issues/271) We'll have to switch this back to using the version number once that issue is resolved.