### PR TITLE
Fixed so helpCenterUrlKey got passed to subcomponent

### DIFF
--- a/addon/components/help-widget.hbs
+++ b/addon/components/help-widget.hbs
@@ -1,4 +1,4 @@
-<div 
+<div
   class="ember-help-widget {{if this.isOpen "ember-help-widget-open"}}"
   ...attributes
   {{did-insert this.connectChat}}
@@ -17,7 +17,8 @@
               @isShowing={{this.showingHelp}}
               @viewName={{@viewName}}
               @performSearch={{@performSearch}}
-              @fetchSuggestions={{@fetchSuggestions}} />
+              @fetchSuggestions={{@fetchSuggestions}}
+              @helpCenterUrlKey={{@helpCenterUrlKey}} />
             <HelpWidget::Feedback
               @isShowing={{this.showingFeedback}}
               @sendFeedback={{@sendFeedback}} />
@@ -56,7 +57,7 @@
               {{/if}}
             </div>
           </div>
-        </div> 
+        </div>
       </div>
     {{/animated-if}}
   </AnimatedContainer>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cph/ember-help-widget",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Used 0.1.5 in LSB but it didn't work.  Oh I didn't pass on the argument.  🤦  If I ruled the ember world there would be a way to access arguments passed to the main component.