### PR TITLE
[fix] Update ws to 8.21.0 (CVE-2026-48779)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "set-value": "^4.0.1",
     "ssri": "^8.0.1",
     "tmp": "^0.2.4",
-    "ws": "^8.17.1"
+    "ws": "^8.21.0"
   },
   "dependencies": {
     "@glimmer/component": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12090,10 +12090,10 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-ws@^8.17.1, ws@~8.11.0, ws@~8.17.1:
-  version "8.17.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
-  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
+ws@^8.21.0, ws@~8.11.0, ws@~8.17.1:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 xdg-basedir@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Bumps `ws` from 8.17.1 to 8.21.0 to resolve a denial-of-service vulnerability in WebSocket request handling. Why: [CVE-2026-48779](https://github.com/advisories/GHSA-96hv-2xvq-fx4p).