### PR TITLE
Pinned linkify-it to 5.0.2 to address CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "glob-parent": "^5.1.2",
     "json5": "^2.2.3",
     "json-schema": "^0.4.0",
+    "linkify-it": "^5.0.1",
     "minimist": "^1.2.6",
     "normalize-url": "^4.5",
     "package-json": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8833,19 +8833,12 @@ line-stream@0.0.0:
   dependencies:
     through "~2.2.0"
 
-linkify-it@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.2.0.tgz#e3b54697e78bf915c70a38acd78fd09e0058b1cf"
-  integrity sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==
+linkify-it@^2.0.0, linkify-it@^3.0.1, linkify-it@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-5.0.2.tgz#d3be0a693af3da9df3883f1e346a0e97461a8c19"
+  integrity sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==
   dependencies:
-    uc.micro "^1.0.1"
-
-linkify-it@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-3.0.3.tgz#a98baf44ce45a550efb4d49c769d07524cc2fa2e"
-  integrity sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==
-  dependencies:
-    uc.micro "^1.0.1"
+    uc.micro "^2.0.0"
 
 livereload-js@^3.3.1:
   version "3.4.0"
@@ -11730,10 +11723,15 @@ typescript-memoize@^1.0.0-alpha.3, typescript-memoize@^1.0.1:
   resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.1.0.tgz#4a8f512d06fc995167c703a3592219901db8bc79"
   integrity sha512-LQPKVXK8QrBBkL/zclE6YgSWn0I8ew5m0Lf+XL00IwMhlotqRLlzHV+BRrljVQIc+NohUAuQP7mg4HQwrx5Xbg==
 
-uc.micro@^1.0.1, uc.micro@^1.0.5:
+uc.micro@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
+
+uc.micro@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-2.1.0.tgz#f8d3f7d0ec4c3dea35a7e3c8efa4cb8b45c9e7ee"
+  integrity sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==
 
 uglify-js@^3.1.4:
   version "3.16.1"


### PR DESCRIPTION
### The bug 🐛

Ran into [GHSA-22p9-wv53-3rq4](https://github.com/advisories/GHSA-22p9-wv53-3rq4) — `linkify-it` has a ReDoS in `match()`, CVSS 8.7. We don't depend on it directly, it's pulled in twice through `markdown-it`. Both copies (`2.2.0` and `3.0.3`) were below the patched `5.0.1`.

### Proposed Solution

Pinned it via yarn `resolutions` to `^5.0.1`, landed on `5.0.2`. Was a little worried since the [changelog](https://github.com/markdown-it/linkify-it/blob/master/CHANGELOG.md) calls 5.0.0 an "ESM rewrite" — but looking at the published package, it still exports CJS (`require` → `build/index.cjs.js`) and the API surface (`test`, `match`, `pretest`, `tlds`) looks the same, so should be safe for our CJS `markdown-it` versions.

## Testing Notes

- `yarn why linkify-it` shows one resolved copy at `5.0.2` now.
- `yarn test:ember` fails, but same failure happens on `main` without this change (looks like a stale babel plugin in node_modules, not related to this).
- Diff is small — `package.json` +1 line, `yarn.lock` 12+/13-, no full lockfile rewrite.